### PR TITLE
upd(djinfo.js): track info left position, camelot + key

### DIFF
--- a/djinfo.js
+++ b/djinfo.js
@@ -135,7 +135,8 @@
     Spicetify.LocalStorage.get("dj-playlists-enabled") == 1 || Spicetify.LocalStorage.get("dj-playlists-enabled") == null;
   isNowPlayingEnabled =
     Spicetify.LocalStorage.get("dj-nowplaying-enabled") == 1 || Spicetify.LocalStorage.get("dj-nowplaying-enabled") == null;
-  isLeftPlayingEnabled = Spicetify.LocalStorage.get("dj-left-playing-enabled") == 1 || Spicetify.LocalStorage.get("dj-left-playing-enabled") == null;
+  isLeftPlayingEnabled =
+    Spicetify.LocalStorage.get("dj-left-playing-enabled") == 1 || Spicetify.LocalStorage.get("dj-left-playing-enabled") == null;
   isBPMEnabled = Spicetify.LocalStorage.get("dj-bpm-enabled") == 1 || Spicetify.LocalStorage.get("dj-bpm-enabled") == null;
   isKeyEnabled = Spicetify.LocalStorage.get("dj-key-enabled") == 1 || Spicetify.LocalStorage.get("dj-key-enabled") == null;
   isPopularityEnabled =
@@ -160,16 +161,10 @@
     Spicetify.LocalStorage.set("dj-nowplaying-enabled", isNowPlayingEnabled ? 1 : 0);
   });
 
-  const enableLeftPlaying = new Spicetify.Menu.Item("Enable Left Now Playing Position", isLeftPlayingEnabled, (item) => {
+  const enableLeftPlaying = new Spicetify.Menu.Item("Use Left side (Now Playing)", isLeftPlayingEnabled, (item) => {
     isLeftPlayingEnabled = !isLeftPlayingEnabled;
     item.setState(isLeftPlayingEnabled);
-    Spicetify.LocalStorage.set("dj-nowplaying-enabled", isLeftPlayingEnabled ? 1 : 0);
-  });
-
-  const enableBPM = new Spicetify.Menu.Item("Enable BPM", isBPMEnabled, (item) => {
-    isBPMEnabled = !isBPMEnabled;
-    item.setState(isBPMEnabled);
-    Spicetify.LocalStorage.set("dj-bpm-enabled", isBPMEnabled ? 1 : 0);
+    Spicetify.LocalStorage.set("dj-left-playing-enabled", isLeftPlayingEnabled ? 1 : 0);
   });
 
   const enableKey = new Spicetify.Menu.Item("Enable Key", isKeyEnabled, (item) => {
@@ -178,10 +173,16 @@
     Spicetify.LocalStorage.set("dj-key-enabled", isKeyEnabled ? 1 : 0);
   });
 
-  const enablePopularity = new Spicetify.Menu.Item("Enable Popularity", isPopularityEnabled, (item) => {
-    isPopularityEnabled = !isPopularityEnabled;
-    item.setState(isPopularityEnabled);
-    Spicetify.LocalStorage.set("dj-popularity-enabled", isPopularityEnabled ? 1 : 0);
+  const enableCamelot = new Spicetify.Menu.Item("Enable Camelot", isCamelotEnabled, (item) => {
+    isCamelotEnabled = !isCamelotEnabled;
+    item.setState(isCamelotEnabled);
+    Spicetify.LocalStorage.set("dj-camelot-enabled", isCamelotEnabled ? 1 : 0);
+  });
+
+  const enableBPM = new Spicetify.Menu.Item("Enable BPM", isBPMEnabled, (item) => {
+    isBPMEnabled = !isBPMEnabled;
+    item.setState(isBPMEnabled);
+    Spicetify.LocalStorage.set("dj-bpm-enabled", isBPMEnabled ? 1 : 0);
   });
 
   const enableEnergy = new Spicetify.Menu.Item("Enable Energy", isEnergyEnabled, (item) => {
@@ -196,16 +197,16 @@
     Spicetify.LocalStorage.set("dj-dance-enabled", isDanceEnabled ? 1 : 0);
   });
 
+  const enablePopularity = new Spicetify.Menu.Item("Enable Popularity", isPopularityEnabled, (item) => {
+    isPopularityEnabled = !isPopularityEnabled;
+    item.setState(isPopularityEnabled);
+    Spicetify.LocalStorage.set("dj-popularity-enabled", isPopularityEnabled ? 1 : 0);
+  });
+
   const enableYear = new Spicetify.Menu.Item("Enable Year", isYearEnabled, (item) => {
     isYearEnabled = !isYearEnabled;
     item.setState(isYearEnabled);
     Spicetify.LocalStorage.set("dj-year-enabled", isYearEnabled ? 1 : 0);
-  });
-
-  const enableCamelot = new Spicetify.Menu.Item("Use Camelot", isCamelotEnabled, (item) => {
-    isCamelotEnabled = !isCamelotEnabled;
-    item.setState(isCamelotEnabled);
-    Spicetify.LocalStorage.set("dj-camelot-enabled", isCamelotEnabled ? 1 : 0);
   });
 
   const reload = new Spicetify.Menu.Item("⨠ Apply Changes", false, (item) => {
@@ -527,8 +528,7 @@
       const trackInfo = await waitForElement(".main-nowPlayingWidget-nowPlaying .main-trackInfo-container");
       if (isLeftPlayingEnabled) {
         nowPlayingWidget.insertBefore(nowPlayingWidgetdjInfoData, trackInfo);
-      }
-      if (!isLeftPlayingEnabled) {
+      } else {
         trackInfo.after(nowPlayingWidgetdjInfoData);
       }
       updateNowPlayingWidget();


### PR DESCRIPTION
Hey, an awesome work!
I've made some small changes for myself, maybe it could be useful for the main branch.

- New option for displaying track info before track name, after the cover
- Display key and camelot at the same time, if two options selected