### PR TITLE
upd(djinfo.js): remove add from recomendations

### DIFF
--- a/djinfo.js
+++ b/djinfo.js
@@ -595,8 +595,9 @@ button.btn:hover {
               track.setAttribute("style", fourColumnGridCss);
               break;
             default:
-              console.log("not 3 columns in Recommendations");
-              break;
+              let addButton = lastColumn.querySelector(".encore-text-body-small-bold")
+              lastColumn.removeChild(addButton)
+              console.log("not 3 columns in Recommendations, removing add button");
           }
 
           if (!trackUri || hasdjinfo || !isTrack) continue;


### PR DESCRIPTION
Hey! I added a small hack to kind of fix the problem with the DJ info in the recommendations.
If the grid in the recommendations isn't three columns long (which seems to be the case in every case), remove the add button. It is a little annoying and prevents the user from seeing the actual info.